### PR TITLE
Fix Vite config and add ES module flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@types/react": "^18.2.47",
         "@types/react-dom": "^18.2.17",
-        "@vitejs/plugin-react": "^4.2.1",
+        "@vitejs/plugin-react": "^4.7.0",
         "autoprefixer": "^10.4.19",
         "eslint": "^8.56.0",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -3372,6 +3372,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "violet-os-re3",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -15,7 +16,7 @@
   "devDependencies": {
     "@types/react": "^18.2.47",
     "@types/react-dom": "^18.2.17",
-    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react": "^4.7.0",
     "autoprefixer": "^10.4.19",
     "eslint": "^8.56.0",
     "eslint-plugin-react-hooks": "^4.6.0",


### PR DESCRIPTION
## Summary
- ensure `@vitejs/plugin-react` is installed as devDependency
- add `"type": "module"` to `package.json`
- update lockfile

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688098abd6a4832e96f84c4e617b124a