### PR TITLE
Add mySalon layout data with UI rendering

### DIFF
--- a/src/pages/MySalon.tsx
+++ b/src/pages/MySalon.tsx
@@ -1,14 +1,26 @@
 import React from 'react'
+import { mySalonLayout } from '../shared/data/mySalon'
 
 export default function MySalon() {
   return (
     <div className="relative w-screen h-screen flex items-center justify-center bg-gray-100">
       {/* 3Dルーム画像 */}
       <img
-        src="/assets/room-basic.png"
+        src={mySalonLayout.background}
         alt="Room"
         className="max-w-full max-h-full object-contain"
       />
+
+      {/* 配置オブジェクト */}
+      {mySalonLayout.objects.map((obj) => (
+        <div
+          key={obj.id}
+          className="absolute text-xs bg-white/80 px-1 rounded"
+          style={{ left: `${obj.position[0] * 80}px`, top: `${obj.position[1] * 80}px` }}
+        >
+          {obj.name}
+        </div>
+      ))}
 
       {/* Violet OS ロゴ */}
       <img src="/assets/logo.png" alt="Violet OS" className="absolute top-4 right-4 w-24" />
@@ -16,11 +28,14 @@ export default function MySalon() {
       {/* ユーザー情報 */}
       <div className="absolute top-4 left-4 flex items-center space-x-4 bg-white/80 p-2 rounded">
         <img src="/assets/avatar.png" alt="avatar" className="w-10 h-10 rounded-full" />
-        <div className="text-xs leading-tight space-x-2">
-          <span>💰1.8k</span>
-          <span>💎45</span>
-          <span>🧠320</span>
-          <span>⭐150</span>
+        <div className="text-xs leading-tight">
+          <div className="font-bold">{mySalonLayout.owner.name} Lv.{mySalonLayout.owner.level}</div>
+          <div className="space-x-2">
+            <span>💰{mySalonLayout.owner.vitcoin}</span>
+            <span>💎{mySalonLayout.owner.vDiamond}</span>
+            <span>🧠{mySalonLayout.owner.skillPoint}</span>
+            <span>⭐{mySalonLayout.owner.famePoint}</span>
+          </div>
         </div>
       </div>
 

--- a/src/shared/data/mySalon.ts
+++ b/src/shared/data/mySalon.ts
@@ -1,0 +1,16 @@
+export const mySalonLayout = {
+  background: "/assets/room-basic.png",
+  owner: {
+    name: "ほだか",
+    level: 12,
+    vitcoin: 1800,
+    vDiamond: 45,
+    skillPoint: 320,
+    famePoint: 150,
+  },
+  objects: [
+    { id: "plant", name: "観葉植物", position: [1, 1] },
+    { id: "sofa", name: "ソファ", position: [2, 1] },
+    { id: "chair", name: "椅子", position: [1, 2] },
+  ],
+} as const


### PR DESCRIPTION
## Summary
- create `mySalonLayout` data under `src/shared`
- load layout data in the MySalon page and show info dynamically
- render object labels based on the layout

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883153f1748832ea606e96c56b72b8a