### PR TITLE
Display objects in MySalon

### DIFF
--- a/src/components/SalonObject.tsx
+++ b/src/components/SalonObject.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+
+type Props = {
+  name: string
+  position: [number, number]
+}
+
+export const SalonObject = ({ name, position }: Props) => {
+  const [x, y] = position
+  return (
+    <div
+      className="absolute text-xs bg-white px-2 py-1 rounded shadow"
+      style={{ left: `${x * 100}px`, top: `${y * 100}px` }}
+    >
+      {name}
+    </div>
+  )
+}

--- a/src/pages/MySalon.tsx
+++ b/src/pages/MySalon.tsx
@@ -1,26 +1,23 @@
 import React from 'react'
-import { mySalonLayout } from '../shared/data/mySalon'
+import { SalonObject } from '@/components/SalonObject'
+import { mySalonLayout } from '@/shared/data/mySalon'
 
 export default function MySalon() {
   return (
     <div className="relative w-screen h-screen flex items-center justify-center bg-gray-100">
-      {/* 3Dルーム画像 */}
-      <img
-        src={mySalonLayout.background}
-        alt="Room"
-        className="max-w-full max-h-full object-contain"
-      />
+      {/* 3Dルーム画像とオブジェクト配置エリア */}
+      <div className="relative">
+        <img
+          src={mySalonLayout.background}
+          alt="Room"
+          className="max-w-full max-h-full object-contain"
+        />
 
-      {/* 配置オブジェクト */}
-      {mySalonLayout.objects.map((obj) => (
-        <div
-          key={obj.id}
-          className="absolute text-xs bg-white/80 px-1 rounded"
-          style={{ left: `${obj.position[0] * 80}px`, top: `${obj.position[1] * 80}px` }}
-        >
-          {obj.name}
-        </div>
-      ))}
+        {/* 配置オブジェクト */}
+        {mySalonLayout.objects.map((obj) => (
+          <SalonObject key={obj.id} name={obj.name} position={obj.position} />
+        ))}
+      </div>
 
       {/* Violet OS ロゴ */}
       <img src="/assets/logo.png" alt="Violet OS" className="absolute top-4 right-4 w-24" />

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,6 +6,10 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    },
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
+import { fileURLToPath, URL } from 'url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add `SalonObject` component
- show salon objects via `mySalonLayout.objects`
- configure `@` alias in Vite and TS config

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68831688ffa8832e8e1401eea141c3f9