### PR TITLE
Add drag handling for salon furniture

### DIFF
--- a/src/components/SalonObject.tsx
+++ b/src/components/SalonObject.tsx
@@ -1,20 +1,53 @@
-import React from "react"
+import React, { useEffect, useRef } from "react"
 
 type Props = {
   name: string
   position: [number, number]
   selected?: boolean
   onClick?: () => void
+  onMove?: (pos: [number, number]) => void
 }
 
-export const SalonObject = ({ name, position, selected, onClick }: Props) => {
+export const SalonObject = ({ name, position, selected, onClick, onMove }: Props) => {
   const [x, y] = position
+  const ref = useRef<HTMLDivElement>(null)
+  const dragging = useRef(false)
+  const offset = useRef({ x: 0, y: 0 })
+
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    dragging.current = true
+    const rect = ref.current!.getBoundingClientRect()
+    offset.current = { x: e.clientX - rect.left, y: e.clientY - rect.top }
+    e.stopPropagation()
+  }
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!dragging.current) return
+      if (!ref.current) return
+      const parentRect = ref.current.parentElement!.getBoundingClientRect()
+      const newX = (e.clientX - parentRect.left - offset.current.x) / 100
+      const newY = (e.clientY - parentRect.top - offset.current.y) / 100
+      onMove?.([parseFloat(newX.toFixed(2)), parseFloat(newY.toFixed(2))])
+    }
+    const handleMouseUp = () => {
+      dragging.current = false
+    }
+    window.addEventListener('mousemove', handleMouseMove)
+    window.addEventListener('mouseup', handleMouseUp)
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove)
+      window.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [onMove])
   return (
     <div
       onClick={onClick}
+      onMouseDown={handleMouseDown}
       className={`absolute text-xs bg-white px-2 py-1 rounded shadow cursor-pointer ${
         selected ? 'ring-2 ring-blue-500' : ''
       }`}
+      ref={ref}
       style={{ left: `${x * 100}px`, top: `${y * 100}px` }}
     >
       {name}

--- a/src/pages/MySalon.tsx
+++ b/src/pages/MySalon.tsx
@@ -33,6 +33,10 @@ export default function MySalon() {
     setShowList(false)
   }
 
+  const handleMoveObject = (uid: string, pos: [number, number]) => {
+    setObjects((prev) => prev.map((o) => (o.uid === uid ? { ...o, position: pos } : o)))
+  }
+
   const handleRemoveSelected = () => {
     if (!selectedUid) return
     setObjects((prev) => prev.filter((o) => o.uid !== selectedUid))
@@ -53,6 +57,7 @@ export default function MySalon() {
             position={obj.position}
             selected={selectedUid === obj.uid}
             onClick={() => setSelectedUid(obj.uid)}
+            onMove={(pos) => handleMoveObject(obj.uid, pos)}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- enable dragging on SalonObject
- move object coordinates in `MySalon` state
- persist updated positions to localStorage

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688331e7df98832e91c2d600ffd38a51